### PR TITLE
Fix module path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ghat
+module github.com/jameswoolfenden/ghat
 
 go 1.22.2
 


### PR DESCRIPTION
Installing it via `go install` now gets:

```
go install  github.com/jameswoolfenden/ghat@latest

go: downloading github.com/jameswoolfenden/ghat v0.1.5
go: github.com/jameswoolfenden/ghat@latest: version constraints conflict:
	github.com/jameswoolfenden/ghat@v0.1.5: parsing go.mod:
	module declares its path as: ghat
	        but was required as: github.com/jameswoolfenden/ghat
```