### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         - id: terraform-fmt
           language_version: python3.11
       repo: https://github.com/jameswoolfenden/pre-commit
-      rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
+      rev: e022e4ac6ed682e95d1e813ee62d4fece371014b # v0.1.53
     - hooks:
         - id: golangci-lint
       repo: https://github.com/golangci/golangci-lint


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.