### PR TITLE
chore(ci): source Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       ## this will contain a matrix of all the combinations
       ## we wish to test again:
       matrix:
-        go-version: [ 1.25.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
 
     ## Defines the platform for each test run
@@ -34,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/ghat.yml
+++ b/.github/workflows/ghat.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: JamesWoolfenden/ghat@a386050ae690ce55f567aaf177fa0516427f014a # v0.1.28
+      - uses: JamesWoolfenden/ghat@e60f56cec93d64866fa82cf6511ce7c0cd92bb20 # v0.1.29
         with:
           directory: .
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - name: gofumpt
         env:
           GOTOOLCHAIN: auto
@@ -24,7 +24,6 @@ jobs:
       GOTOOLCHAIN: auto
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -33,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: Build
         run: go build ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0


### PR DESCRIPTION
Switch all workflows to `go-version-file: go.mod` so the Go version is single-sourced. Drop the single-value go-version matrix dimension. Checkout already runs before setup-go in all jobs, so no reordering needed.

Includes ghat-driven SHA bump for JamesWoolfenden/ghat in ghat.yml.